### PR TITLE
feat: adiciona configuração de serviço para backend em render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,17 @@
+services:
+  - type: web
+    name: wavelength-backend
+    env: python
+    region: oregon
+    plan: free
+    branch: main
+    rootDir: Back-End
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn src.main:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.11.0
+      - key: PORT
+        value: 10000
+      - key: USE_MOCK_AI
+        value: false


### PR DESCRIPTION
- Novo arquivo render.yaml criado para definir o serviço wavelength-backend
- Configurações incluem ambiente Python, região, plano, comandos de build e start, e variáveis de ambiente